### PR TITLE
Patch continued statement indentation when inside a block.

### DIFF
--- a/cperl-mode.el
+++ b/cperl-mode.el
@@ -3143,7 +3143,9 @@ and closing parentheses and brackets."
 	 ((eq 'continuation (elt i 0))
 	  ;; [continuation statement-start char-after is-block is-brace]
 	  (goto-char (elt i 1))		; statement-start
-	  (+ (if (memq (elt i 2) (append "}])" nil)) ; char-after
+	  (+ (if (or (memq (elt i 2) (append "}])" nil)) ; char-after
+                     (eq 'continuation ; do not repeat cperl-close-paren-offset
+                         (elt (cperl-sniff-for-indent parse-data) 0)))
 		 0			; Closing parenth
 	       cperl-continued-statement-offset)
 	     (if (or (elt i 3)		; is-block


### PR DESCRIPTION
See http://stackoverflow.com/a/14043345/14660 for discussion and original patch.  The patch is by http://stackoverflow.com/users/850781/sds  The staircase bug is also [discussed on the EmacsWiki](http://www.emacswiki.org/emacs/IndentingPerl#toc3).

For example, with this in .emacs

(setq cperl-indent-level 4                ; 4 character indents
      cperl-indent-parens-as-block t      ; indent parens like blocks
      cperl-continued-statement-offset 2
      cperl-continued-brace-offset 0
      cperl-close-paren-offset -4
      cperl-tabs-always-indent nil
)

Without the patch it indents like this.

role {
    has foo =>
      is      => 'rw',
        isa     => 'Int',
          default => 0;
}

With the patch it indents correctly.

role {
    has foo =>
      is      => 'rw',
      isa     => 'Int',
      default => 0;
}

Note the presense of a block around the statement is necessary.  Without the block
the bug does not appear.
