### PR TITLE
Suppress warnings about '(lambda ...) in edgy emacs

### DIFF
--- a/cperl-mode.el
+++ b/cperl-mode.el
@@ -8577,7 +8577,7 @@ the appropriate statement modifier."
             (pargs (cdr (car flist))))
         (setq command
               (concat command " | " pcom " "
-                      (mapconcat '(lambda (phrase)
+                      (mapconcat #'(lambda (phrase)
                                     (if (not (stringp phrase))
                                         (error "Malformed Man-filter-list"))
                                     phrase)


### PR DESCRIPTION
Switching from '(lambda ...) to #'(lambda ...) makes emacs built from the HEAD stop complaining. Which is nice.
