### PR TITLE
fix continued expression indentation when cperl-indent-parens-as-block in effect

### DIFF
--- a/cperl-mode.el
+++ b/cperl-mode.el
@@ -2929,6 +2929,8 @@ Will not look before LIM."
 		     (cperl-backward-to-noncomment containing-sexp))
 		   ;; Now we get non-label preceeding the indent point
 		   (if (not (or (eq (1- (point)) containing-sexp)
+                                (and cperl-indent-parens-as-block
+                                     (not is-block))
 				(memq (preceding-char)
 				      (append (if is-block " ;{" " ,;{") '(nil)))
 				(and (eq (preceding-char) ?\})


### PR DESCRIPTION
When cperl-indent-parens-as-block is in effect, expressions are indented incorrectly:

```
if ($var1 == 1 &&
      $var2 == 2 &&
      $var3 == 3) {
  ...
}
```

this patch fixes the indentation:

```
if ($var1 == 1 &&
    $var2 == 2 &&
    $var3 == 3) {
  ...
}
```

I'm working with this patch applied over one month and I didn't notice negative side effects.
Please test it and apply to upstream.
