### PR TITLE
missing parentheses added

### DIFF
--- a/cperl-mode.el
+++ b/cperl-mode.el
@@ -6959,7 +6959,7 @@ by CPerl."
 			(number-to-string (1- (elt elt 1))) ; Char pos 0-based
 			"\n")
 		(if (and (string-match "^[_a-zA-Z]+::" (car elt))
-			 (string-match "^" cperl-sub-regexp "[ \t]+\\([_a-zA-Z]+\\)[^:_a-zA-Z]"
+			 (string-match (concat "^" cperl-sub-regexp "[ \t]+\\([_a-zA-Z]+\\)[^:_a-zA-Z]")
 				       (elt elt 3)))
 		    ;; Need to insert the name without package as well
 		    (setq lst (cons (cons (substring (elt elt 3)


### PR DESCRIPTION
I tried to byte-compile cperl-mode.el. There were several warnings, this one seemed the most harmful:

```
In cperl-find-tags:
cperl-mode.el:6965:55:Warning: string-match called with 4 arguments, but
    accepts only 2-3
```

It seems there is a missing `(concat ...)`.
