### PR TITLE
Run prog-mode-hook hooks.

### DIFF
--- a/cperl-mode.el
+++ b/cperl-mode.el
@@ -1920,6 +1920,7 @@ or as help on variables `cperl-tips', `cperl-problems',
        (cperl-msb-fix))
   (if (featurep 'easymenu)
       (easy-menu-add cperl-menu))	; A NOP in Emacs.
+  (run-hooks 'prog-mode-hook)
   (run-mode-hooks 'cperl-mode-hook)
   (if cperl-hook-after-change
       (add-hook 'after-change-functions 'cperl-after-change-function nil t))


### PR DESCRIPTION
In new emacs we have a cool define-derived-mode macro. So most programming modes inherit from prog-mode and run prog-mode-hook.
However I'am not sure how to do it correctly for cperl-mode... must I use run-mode-hooks here or may be it is totally wrong idea?
