### PR TITLE
Bugfix: Recognize that { $a++ / $b } is a division, not a regex.

### DIFF
--- a/cperl-mode.el
+++ b/cperl-mode.el
@@ -4156,6 +4156,9 @@ the sections using `cperl-pod-head-face', `cperl-pod-face',
 				    (and (eq (preceding-char) ?.)
 					 (eq (char-after (- (point) 2)) ?.))
 				    (bobp))
+				;; { $a++ / $b } doesn't start a regex, nor does $a--
+				(not (and (memq (preceding-char) '(?+ ?-))
+					  (eq (preceding-char) (char-before (1- (point))))))
 				;;  m|blah| ? foo : bar;
 				(not
 				 (and (eq c ?\?)


### PR DESCRIPTION
This has been observed by @choroba in issue #45.
The solution is yet another special case where we need to look back
one more character to check whether '+' or '-' are infix operators.

Background: I've missed this repository when I started to hack on cperl-mode myself.
I did too much refactoring in my own experiments to throw all that as a PR over the fence, though.