### PR TITLE
Fix byte-compile error about make-obsolete when argument in Emacs 28

### DIFF
--- a/cperl-mode.el
+++ b/cperl-mode.el
@@ -427,7 +427,8 @@ Affects: `cperl-font-lock', `cperl-electric-lbrace-space',
 (defvar cperl-vc-header-alist nil)
 (make-obsolete-variable
  'cperl-vc-header-alist
- "use cperl-vc-rcs-header or cperl-vc-sccs-header instead.")
+ "use cperl-vc-rcs-header or cperl-vc-sccs-header instead."
+ "cperl-mode 6.3")
 
 (defcustom cperl-clobber-mode-lists
   (not

--- a/cperl-mode.el
+++ b/cperl-mode.el
@@ -428,7 +428,7 @@ Affects: `cperl-font-lock', `cperl-electric-lbrace-space',
 (make-obsolete-variable
  'cperl-vc-header-alist
  "use cperl-vc-rcs-header or cperl-vc-sccs-header instead."
- "cperl-mode 6.3")
+ "cperl-mode 5.3")
 
 (defcustom cperl-clobber-mode-lists
   (not


### PR DESCRIPTION
In Emacs 28, `when` argument of `make-obsolete` is mandatory. https://github.com/emacs-mirror/emacs/commit/32c6732d16385f242b1109517f25e9aefd6caa5c

cperl-mode byte-compile error occured by this change.

`cperl-vc-header-alist` is obsolete after 5.3 tag. So, add when argument `cperl-mode 6.3` .

https://github.com/jrockway/cperl-mode/blob/bda53c9569c5314a4cfdb8a542492fcbfc468ed6/cperl-mode.el#L1570-L1577